### PR TITLE
Adding a LICENSE symlink to file in LICENSES

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/MIT.txt


### PR DESCRIPTION
This is a workaround to make GitHub detect the "main" license of the code base.